### PR TITLE
Add Telegram token

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,10 @@ source: https://developer.twitter.com/en/docs/authentication/guides/authenticati
 - TRAVIS_SECURE_ENV_VARS
 
 source: https://docs.travis-ci.com/user/environment-variables
+
+## Telegram
+- TELEGRAM_BOT_TOKEN
+
 # U
 # V
 ## Vault HashiCorp


### PR DESCRIPTION
## Add Telegram bot token

Sorry i cant find the source, but many repos using "TELEGRAM_BOT_TOKEN" as its bot token

- [BoShurik/telegram-bot](https://github.com/BoShurik/telegram-bot-example/blob/master/.env)
- [telegram-rs/telegram-bot](https://github.com/telegram-rs/telegram-bot/blob/main/lib/examples/simple.rs)
- [IoBT-VISTEC/MetaSleepLearner](https://github.com/IoBT-VISTEC/MetaSleepLearner/blob/main/bot.py)
- [dideler's gist](https://gist.github.com/dideler/85de4d64f66c1966788c1b2304b9caf1)
etc ....